### PR TITLE
Allow reader to be read multiple times

### DIFF
--- a/pkg/lazy/LazyReadCloser.go
+++ b/pkg/lazy/LazyReadCloser.go
@@ -33,6 +33,7 @@ func (r *LazyReadCloser) Read(p []byte) (int, error) {
 }
 
 func (r *LazyReadCloser) Close() error {
+	r.err = nil
 	if r.readCloser != nil {
 		defer func() { r.readCloser = nil }()
 		return r.readCloser.Close()

--- a/pkg/lazy/LazyReadCloser.go
+++ b/pkg/lazy/LazyReadCloser.go
@@ -34,6 +34,7 @@ func (r *LazyReadCloser) Read(p []byte) (int, error) {
 
 func (r *LazyReadCloser) Close() error {
 	if r.readCloser != nil {
+		defer func() { r.readCloser = nil }()
 		return r.readCloser.Close()
 	}
 	return nil

--- a/pkg/lazy/LazyReadCloser_test.go
+++ b/pkg/lazy/LazyReadCloser_test.go
@@ -30,6 +30,22 @@ func TestLazyReadCloser(t *testing.T) {
 	assert.NoError(t, rc.Close())
 }
 
+func TestLazyReadCloserTwice(t *testing.T) {
+	in := "hello world"
+	rc := NewLazyReadCloser(func() (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(in)), nil
+	})
+	assert.NoError(t, rc.Close()) // calling close before reading any data should return nil
+	out, err := io.ReadAll(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, in, string(out))
+	assert.NoError(t, rc.Close())
+	out, err = io.ReadAll(rc)
+	assert.NoError(t, err)
+	assert.Equal(t, in, string(out))
+	assert.NoError(t, rc.Close())
+}
+
 func TestLazyReadCloserMulti(t *testing.T) {
 	opened := 0
 	r := io.MultiReader(


### PR DESCRIPTION
This allows re-reading the file multiple times which can be useful when using the s3manager and something goes wrong outside the file read.